### PR TITLE
feat: fiber 아키텍쳐 도입

### DIFF
--- a/src/__tests__/fiber.test.ts
+++ b/src/__tests__/fiber.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, test, expect, beforeEach } from "vitest";
+import { createElement } from "@/jsx/createElement";
+import { createFiberTree } from "@/fiber/createFiberTree";
+import { beginWork } from "@/fiber/beginWork";
+import { completeWork } from "@/fiber/completeWokr";
+import { commitWork } from "@/fiber/commitWork";
+
+describe("Fiber 렌더링 사이클 (Vanilla ReactCore) - DOM commit 테스트", () => {
+  beforeEach(() => {
+    // 테스트 전마다 DOM 초기화
+    document.body.innerHTML = "";
+  });
+
+  test("createElement → commitWork까지 전체 흐름에서 DOM이 정상 생성된다", () => {
+    // 1. JSX 기반 구조 정의
+    const vnode = createElement(
+      "div",
+      null,
+      createElement("span", null),
+      createElement("button", null)
+    );
+
+    // 2. Fiber 트리 생성
+    const root = createFiberTree(vnode, null);
+
+    // 3. Render Phase 실행
+    beginWork(root);
+    completeWork(root);
+
+    // 4. Commit Phase 실행
+    commitWork(root);
+
+    // 5. DOM 검증
+    const div = document.body.querySelector("div");
+    const span = div?.querySelector("span");
+    const button = div?.querySelector("button");
+
+    expect(document.body.innerHTML).toBe(
+      "<div><span></span><button></button></div>"
+    );
+    expect(div).not.toBeNull();
+    expect(span).not.toBeNull();
+    expect(button).not.toBeNull();
+  });
+});

--- a/src/dom/createDOMElement.ts
+++ b/src/dom/createDOMElement.ts
@@ -1,8 +1,8 @@
 import { VirtualNode } from "@/jsx/type.jsx";
 
-export const createDOMElement = (
+export function createDOMElement(
   virtualNode: VirtualNode | string
-): HTMLElement | Text => {
+): HTMLElement | Text {
   // 텍스트 노드 처리
   if (typeof virtualNode === "string") {
     return document.createTextNode(virtualNode);
@@ -30,4 +30,4 @@ export const createDOMElement = (
   }
 
   return element;
-};
+}

--- a/src/dom/renderToDOM.ts
+++ b/src/dom/renderToDOM.ts
@@ -1,10 +1,10 @@
 import { createDOMElement } from "./createDOMElement";
 import { VirtualNode } from "@/jsx/type.jsx";
 
-export const renderToDOM = (
+export function renderToDOM(
   virtunalNode: VirtualNode | string,
   container: HTMLElement
-): void => {
+): void {
   const dom = createDOMElement(virtunalNode);
   container.appendChild(dom);
-};
+}

--- a/src/fiber/beginWork.ts
+++ b/src/fiber/beginWork.ts
@@ -3,13 +3,10 @@ import { FiberNode } from "./type.fiber";
 export function beginWork(fiber: FiberNode): void {
   if (typeof fiber.type === "string" && !fiber.stateNode) {
     fiber.flags = "Placement";
+    console.log(`[beginWork] ${fiber.type} → flags = Placement`);
   }
 
-  if (fiber.child) {
-    beginWork(fiber.child);
-  }
+  if (fiber.child) beginWork(fiber.child);
 
-  if (fiber.sibling) {
-    beginWork(fiber.sibling);
-  }
+  if (fiber.sibling) beginWork(fiber.sibling);
 }

--- a/src/fiber/beginWork.ts
+++ b/src/fiber/beginWork.ts
@@ -1,0 +1,15 @@
+import { FiberNode } from "./type.fiber";
+
+export function beginWork(fiber: FiberNode): void {
+  if (typeof fiber.type === "string" && !fiber.stateNode) {
+    fiber.flags = "Placement";
+  }
+
+  if (fiber.child) {
+    beginWork(fiber.child);
+  }
+
+  if (fiber.sibling) {
+    beginWork(fiber.sibling);
+  }
+}

--- a/src/fiber/commitWork.ts
+++ b/src/fiber/commitWork.ts
@@ -14,24 +14,29 @@ function findHostParent(fiber: FiberNode): HTMLElement | null {
     parent = parent.return;
   }
 
-  // 2. 부모 Fiber가 존재하지 않는 경우 null 반환
-  return null;
+  // 2. 부모 Fiber가 존재하지 않는 경우 body 태그 반환 (body를 root 요소로 설정)
+  return document.body;
 }
 
-export function commitWokr(fiber: FiberNode): void {
+export function commitWork(fiber: FiberNode): void {
   if (fiber.flags === "Placement" && fiber.stateNode) {
     // Parent Fiber가 존재하며, HTML 요소 기반일 경우 자식 요소로 삽입
     const parentDOM = findHostParent(fiber);
-    if (parentDOM) parentDOM.appendChild(fiber.stateNode);
+    if (parentDOM) {
+      parentDOM.appendChild(fiber.stateNode);
+      console.log(
+        `[commitWork] <${fiber.type}> → append to <${parentDOM.tagName}>`
+      );
+    }
   }
 
   // 자식 요소 commit 수행
   if (fiber.child) {
-    commitWokr(fiber.child);
+    commitWork(fiber.child);
   }
 
   // 형제 요소 commit 수행
   if (fiber.sibling) {
-    commitWokr(fiber.sibling);
+    commitWork(fiber.sibling);
   }
 }

--- a/src/fiber/commitWork.ts
+++ b/src/fiber/commitWork.ts
@@ -1,0 +1,37 @@
+import { FiberNode } from "./type.fiber";
+
+function findHostParent(fiber: FiberNode): HTMLElement | null {
+  let parent = fiber.return;
+
+  // 1. 부모 Fiber가 존재하는 경우
+  while (parent) {
+    // 1-1. HTML Element를 기반으로 한 HostComponent일 경우 포인터 반환
+    if (typeof parent.type === "string" && parent.stateNode) {
+      return parent.stateNode;
+    }
+
+    // 1-2. 아닐 경우 트리 상부로 올라가며 부모 Fiber를 계속 탐색
+    parent = parent.return;
+  }
+
+  // 2. 부모 Fiber가 존재하지 않는 경우 null 반환
+  return null;
+}
+
+export function commitWokr(fiber: FiberNode): void {
+  if (fiber.flags === "Placement" && fiber.stateNode) {
+    // Parent Fiber가 존재하며, HTML 요소 기반일 경우 자식 요소로 삽입
+    const parentDOM = findHostParent(fiber);
+    if (parentDOM) parentDOM.appendChild(fiber.stateNode);
+  }
+
+  // 자식 요소 commit 수행
+  if (fiber.child) {
+    commitWokr(fiber.child);
+  }
+
+  // 형제 요소 commit 수행
+  if (fiber.sibling) {
+    commitWokr(fiber.sibling);
+  }
+}

--- a/src/fiber/completeWokr.ts
+++ b/src/fiber/completeWokr.ts
@@ -1,0 +1,12 @@
+import { FiberNode } from "./type.fiber";
+
+export function completeWork(fiber: FiberNode): void {
+  // props 설정
+  fiber.memoizedProps = fiber.pendingProps;
+
+  // 이전에 DOM이 생성되지 않았을 시, 생성 후 포인터에 주소 값 저장
+  if (typeof fiber.type === "string" && fiber.stateNode === null) {
+    const dom = document.createElement(fiber.type);
+    fiber.stateNode = dom;
+  }
+}

--- a/src/fiber/completeWokr.ts
+++ b/src/fiber/completeWokr.ts
@@ -8,5 +8,10 @@ export function completeWork(fiber: FiberNode): void {
   if (typeof fiber.type === "string" && fiber.stateNode === null) {
     const dom = document.createElement(fiber.type);
     fiber.stateNode = dom;
+    console.log(`[completeWork] ${fiber.type} → DOM 생성됨`);
   }
+
+  if (fiber.child) completeWork(fiber.child);
+
+  if (fiber.sibling) completeWork(fiber.sibling);
 }

--- a/src/fiber/createFiberNode.ts
+++ b/src/fiber/createFiberNode.ts
@@ -1,0 +1,23 @@
+import { VirtualNode } from "@/jsx/type.jsx";
+import { FiberNode } from "./type.fiber";
+
+export function createFiberNode(virtualNode: VirtualNode): FiberNode {
+  return {
+    type: virtualNode.type,
+    key: virtualNode.key,
+    stateNode: null,
+
+    child: null,
+    sibling: null,
+    return: null,
+    alternate: null,
+
+    flags: "Placement",
+
+    pendingProps: virtualNode.props,
+    memoizedProps: null,
+
+    memoizedState: null,
+    updateQueue: null,
+  };
+}

--- a/src/fiber/createFiberTree.ts
+++ b/src/fiber/createFiberTree.ts
@@ -1,0 +1,42 @@
+import { createFiberNode } from "./createFiberNode";
+import { VirtualNode } from "@/jsx/type.jsx";
+import { FiberNode } from "./type.fiber";
+
+export function createFiberTree(
+  virtualNode: VirtualNode,
+  parent: FiberNode | null
+): FiberNode {
+  // Fiber Node 생성
+  const fiber = createFiberNode(virtualNode);
+
+  // 부모 Fiber의 참조 저장
+  fiber.return = parent;
+
+  const children = virtualNode.props?.children ?? [];
+
+  // 이전 sibling Fiber 를 추적하는 포인터
+  let preFiber: FiberNode | null = null;
+
+  // Fiber의 children 을 담은 배열 순회
+  children.forEach((childNode, index) => {
+    // 만약 ReactElement가 아닌 string 데이터일 경우, 트리에 삽입하지 않음
+    if (typeof childNode === "string") return;
+
+    // ReactElement일 경우 재귀를 통하여 하부 트리 구성
+    const childFiber = createFiberTree(childNode, fiber);
+
+    // 첫번째 자식 요소일 경우 child 요소의 value로 지정
+    if (index === 0) {
+      fiber.child = childFiber;
+
+      // 이외의 경우 sibling 요소의 value로 지정
+    } else if (preFiber) {
+      preFiber.sibling = childFiber;
+    }
+
+    // 현재 생성된 Fiber를 preFiber로 지정
+    preFiber = childFiber;
+  });
+
+  return fiber;
+}

--- a/src/fiber/type.fiber.ts
+++ b/src/fiber/type.fiber.ts
@@ -1,0 +1,18 @@
+export interface FiberNode {
+  type: string | Function;
+  key: null | string | number;
+  stateNode: HTMLElement | null;
+
+  child: FiberNode | null;
+  sibling: FiberNode | null;
+  return: FiberNode | null;
+  alternate: FiberNode | null;
+
+  flags: "Placement" | "Update" | "Deletion" | null;
+
+  memoizedProps: any;
+  pendingProps: any;
+
+  memoizedState: any;
+  updateQueue: any;
+}

--- a/src/jsx/createElement.ts
+++ b/src/jsx/createElement.ts
@@ -1,11 +1,11 @@
 import { Child, VirtualNode } from "./type.jsx";
 import { normalizeChildren } from "./normalizeChildren";
 
-export const createElement = (
+export function createElement(
   type: string,
   props: Record<string, any> | null,
   ...children: Child[]
-): VirtualNode => {
+): VirtualNode {
   const { key = null, ...restProps } = props || {};
 
   return {
@@ -16,4 +16,4 @@ export const createElement = (
       children: normalizeChildren(children),
     },
   };
-};
+}

--- a/src/jsx/normalizeChildren.ts
+++ b/src/jsx/normalizeChildren.ts
@@ -1,22 +1,22 @@
 import { Child, NormalizedChild, VirtualNode } from "./type.jsx";
 
 // 렌더링 가능한 요소인지 판별하는 함수
-const isRenderable = (child: Child) => {
+function isRenderable(child: Child) {
   return child !== null && child !== undefined && typeof child !== "boolean";
-};
+}
 
 // 객체일 경우 ReactElement인지 판별하는 함수
-const isVirtualNode = (obj: any): obj is VirtualNode => {
+function isVirtualNode(obj: any): obj is VirtualNode {
   return (
     obj !== null &&
     typeof obj === "object" &&
     typeof obj.type === "string" &&
     typeof obj.props === "object"
   );
-};
+}
 
 // Object (ReactElement) 일 경우 그대로 반환, Number 타입일 경우 String 타입으로 변환하여 반환하는 함수
-const toNormalizeChild = (child: Child): NormalizedChild => {
+function toNormalizeChild(child: Child): NormalizedChild {
   if (isVirtualNode(child)) return child;
 
   if (typeof child === "object") {
@@ -25,9 +25,9 @@ const toNormalizeChild = (child: Child): NormalizedChild => {
   }
 
   return String(child);
-};
+}
 
 // 컴포넌트에 children props로 전달된 요소를 처리 가능한 요소로 변환하는 함수
-export const normalizeChildren = (children: Child[]): NormalizedChild[] => {
+export function normalizeChildren(children: Child[]): NormalizedChild[] {
   return children.flat(Infinity).filter(isRenderable).map(toNormalizeChild);
-};
+}


### PR DESCRIPTION
## Result
- `fiber` 아키텍쳐 도입 및 `render-commit` 단계 구분

## Work List
- `React Element`를 기반으로 `fiber` 자료구조 생성
- `beginWork, completeWork, commitWork`로 단계를 나눠서 `render-commit phase` 나눠서 진행되도록 구현

## Discussion
- `while-loop`가 아닌 재귀 기반으로 `fiber` 탐색하도록 구현
- `beginWork`의 `reconcile` 약식으로 구현
- 추후 실제 `React.js` 메커니즘과 유사하게 리팩토링 진행