### PR TITLE
feat: effect hook 구현 (useEffect, useLayoutEffect)

### DIFF
--- a/src/fiber/hooks/flushEffects.ts
+++ b/src/fiber/hooks/flushEffects.ts
@@ -1,0 +1,27 @@
+import { Effect } from "./types";
+
+export function flushLayoutEffect(effects: Effect[]) {
+  effects.forEach((effect) => {
+    if (effect.tag === "Layout") {
+      // 등록된 clean up 함수 실행
+      if (effect.destroy) effect.destroy();
+
+      // 콜백함수 실행 + clean up 함수 갱신
+      const cleanUp = effect.create();
+      if (typeof cleanUp === "function") effect.destroy = cleanUp;
+    }
+  });
+}
+
+export function flushPassiveEffect(effects: Effect[]) {
+  effects.forEach((effect) => {
+    if (effect.tag === "Passive") {
+      // 등록된 clean up 함수 실행
+      if (effect.destroy) effect.destroy();
+
+      // 콜백함수 실행 + clean up 함수 갱신
+      const cleanUp = effect.create();
+      if (typeof cleanUp === "function") effect.destroy = cleanUp;
+    }
+  });
+}

--- a/src/fiber/hooks/types.ts
+++ b/src/fiber/hooks/types.ts
@@ -12,3 +12,10 @@ export interface Hook {
   queue: UpdateQueue; // 상태 갱신 작업을 담는 큐
   next: Hook | null; // 다음 훅을 가리키는 포인터
 }
+
+export interface Effect {
+  create: () => void | (() => void);
+  destroy: (() => void) | null | undefined;
+  deps: any[] | null;
+  tag: "Passive" | "Layout";
+}

--- a/src/fiber/hooks/useEffect.ts
+++ b/src/fiber/hooks/useEffect.ts
@@ -1,0 +1,78 @@
+import { Effect, Hook } from "./types";
+import { getNextHook } from "./getNextHook";
+import { hookContext } from "./context";
+
+type EffectTag = "Passive" | "Layout";
+
+export function useEffect(
+  create: () => void | (() => void),
+  deps: any[] | undefined
+) {
+  updateEffect(create, deps, "Passive");
+}
+
+export function useLayoutEffect(
+  create: () => void | (() => void),
+  deps: any[] | undefined
+) {
+  updateEffect(create, deps, "Layout");
+}
+
+/**
+ * 의존성 배열 변경을 체크하여 effect 실행 리스트에 포함 여부를 결정하는 함수
+ */
+function updateEffect(
+  create: () => void | (() => void),
+  deps: any[] | undefined,
+  tag: EffectTag
+) {
+  const hook = getNextHook();
+  const prevEffect = hook.memoizedState as Effect | null;
+
+  let isDepsChanged = true;
+
+  if (prevEffect && deps && prevEffect.deps) {
+    isDepsChanged = isEffectDepsEqual(deps, prevEffect.deps);
+  }
+
+  if (isDepsChanged) {
+    const effect: Effect = {
+      create,
+      destroy: prevEffect?.destroy,
+      deps: deps ?? null,
+      tag,
+    };
+
+    // fiber memoizedState 갱신
+    hook.memoizedState = effect;
+
+    // commit 후 실행 될 effect 목록에 저장
+    const fiber = hookContext.currentlyRenderingFiber;
+    if (fiber && !fiber?.effects) fiber.effects = [];
+    fiber?.effects?.push(effect);
+
+    if (fiber) {
+      /** flags 타입이 number로 통일되지 않은 상태라 임시 처리 (추후 수정 예정) */
+      if (typeof fiber.flags !== "number") fiber.flags = 0;
+
+      if (tag === "Passive") {
+        fiber.flags |= 0b0010; // PassiveEffect
+      } else {
+        fiber.flags |= 0b0100; // LayoutEffect
+      }
+    }
+  }
+}
+
+/**
+ * useEffect의 의존성 배열에 할당된 값을 얕은 비교하는 함수
+ */
+function isEffectDepsEqual(nextDeps: any[], prevDeps: any[]) {
+  if (nextDeps.length !== prevDeps.length) return false;
+
+  for (let i = 0; i < nextDeps.length; i++) {
+    if (!Object.is(nextDeps[i], prevDeps[i])) return false;
+  }
+
+  return true;
+}

--- a/src/fiber/type.fiber.ts
+++ b/src/fiber/type.fiber.ts
@@ -1,3 +1,5 @@
+import { Effect } from "./hooks/types";
+
 export interface FiberNode {
   type: string | Function;
   key: null | string | number;
@@ -8,11 +10,13 @@ export interface FiberNode {
   return: FiberNode | null;
   alternate: FiberNode | null;
 
-  flags: "Placement" | "Update" | "Deletion" | null;
+  flags: "Placement" | "Update" | "Deletion" | number | null;
 
   memoizedProps: any;
   pendingProps: any;
 
   memoizedState: any;
   updateQueue: any;
+
+  effects?: Effect[];
 }


### PR DESCRIPTION
## Result
- side effect 처리를 위한 effect hook 구현 (`useEffect, useLayoutEffect`)

## Work List
- `commit phase`에서 외부 효과를 처리하는 effect hook 구현                                    
- state와 마찬가지로 fiber 자료구조의 `memoizedState` 속성을 활용하여 관리                    
- effect 실행 여부를 판단하기 위해 `deps`에 할당된 값을 얕은 비교를 활용하여 diff 처리        
- `beginWork`에서 `flag`를 통해 effect의 종류를 구별하고, `commit phase`에서 이를 활용하여 콜백 함수 실행을 제어 (동기, 비동기)   

## Discussion