### PR TITLE
refactor: 재귀 방식의 렌더링 루프를 반복문(while-loop)로 변경

### DIFF
--- a/src/__tests__/fiber.test.ts
+++ b/src/__tests__/fiber.test.ts
@@ -6,7 +6,7 @@ import { describe, test, expect, beforeEach } from "vitest";
 import { createElement } from "@/jsx/createElement";
 import { createFiberTree } from "@/fiber/core/createFiberTree";
 import { beginWork } from "@/fiber/core/beginWork";
-import { completeWork } from "@/fiber/core/completeWokr";
+import { completeWork } from "@/fiber/core/completeWork";
 import { commitWork } from "@/fiber/core/commitWork";
 
 describe("Fiber 렌더링 사이클 (Vanilla ReactCore) - DOM commit 테스트", () => {

--- a/src/fiber/constants.ts
+++ b/src/fiber/constants.ts
@@ -1,0 +1,8 @@
+export const FiberFlags = {
+  NoFlags: 0b0000,
+  Placement: 0b0001,
+  Update: 0b0010,
+  Deletion: 0b0100,
+  PassiveEffect: 0b1000,
+  LayoutEffect: 0b10000,
+} as const;

--- a/src/fiber/core/beginWork.ts
+++ b/src/fiber/core/beginWork.ts
@@ -2,7 +2,7 @@ import { FiberNode } from "../type.fiber";
 import { setFiberFlag } from "../utils.fiber";
 import { FiberFlags } from "../constants";
 
-export function beginWork(fiber: FiberNode): void {
+export function beginWork(fiber: FiberNode): FiberNode | null {
   const prevFiber = fiber.alternate;
 
   const isHostComponent = typeof fiber.type === "string";
@@ -18,6 +18,5 @@ export function beginWork(fiber: FiberNode): void {
     console.log(`[beginWork] ${fiber.type} → flags = Update`);
   }
 
-  if (fiber.child) beginWork(fiber.child);
-  if (fiber.sibling) beginWork(fiber.sibling);
+  return fiber.child;
 }

--- a/src/fiber/core/beginWork.ts
+++ b/src/fiber/core/beginWork.ts
@@ -1,4 +1,6 @@
 import { FiberNode } from "../type.fiber";
+import { setFiberFlag } from "../utils.fiber";
+import { FiberFlags } from "../constants";
 
 export function beginWork(fiber: FiberNode): void {
   const prevFiber = fiber.alternate;
@@ -9,10 +11,10 @@ export function beginWork(fiber: FiberNode): void {
     prevFiber && prevFiber.memoizedProps !== prevFiber.pendingProps;
 
   if (isHostComponent && !hasDOM) {
-    fiber.flags = "Placement";
+    fiber.flags = setFiberFlag(fiber.flags, FiberFlags.Placement);
     console.log(`[beginWork] ${fiber.type} → flags = Placement`);
   } else if (isHostComponent && propsChanged) {
-    fiber.flags = "Update";
+    fiber.flags = setFiberFlag(fiber.flags, FiberFlags.Update);
     console.log(`[beginWork] ${fiber.type} → flags = Update`);
   }
 

--- a/src/fiber/core/commitUnitOfWork.ts
+++ b/src/fiber/core/commitUnitOfWork.ts
@@ -1,0 +1,31 @@
+import { FiberNode } from "../type.fiber";
+import { commitWork } from "./commitWork";
+
+export function commitUnitOfWork(fiber: FiberNode): void {
+  let node: FiberNode | null = fiber;
+
+  while (node !== null) {
+    commitWork(node);
+
+    if (node.child) {
+      node = node.child;
+      continue;
+    }
+
+    if (node.sibling) {
+      node = node.sibling;
+      continue;
+    }
+
+    // sibling이 있는 부모 탐색
+    while (node && node.sibling === null) {
+      node = node.return;
+    }
+
+    if (node && node !== fiber) {
+      node = node.sibling;
+    } else {
+      break;
+    }
+  }
+}

--- a/src/fiber/core/commitWork.ts
+++ b/src/fiber/core/commitWork.ts
@@ -38,9 +38,4 @@ export function commitWork(fiber: FiberNode): void {
       });
     }
   }
-
-  // 자식 요소 commit 수행
-  if (fiber.child) commitWork(fiber.child);
-  // 형제 요소 commit 수행
-  if (fiber.sibling) commitWork(fiber.sibling);
 }

--- a/src/fiber/core/commitWork.ts
+++ b/src/fiber/core/commitWork.ts
@@ -1,10 +1,12 @@
 import { FiberNode } from "../type.fiber";
 import { getHostParent, patchProps } from "../utils.fiber";
 import { flushLayoutEffect, flushPassiveEffect } from "../hooks/flushEffects";
+import { hasFiberFlag } from "../utils.fiber";
+import { FiberFlags } from "../constants";
 
 export function commitWork(fiber: FiberNode): void {
   // 1. Placement 대상일 경우 부모 요소에 apeendChild 처리
-  if (fiber.flags === "Placement" && fiber.stateNode) {
+  if (hasFiberFlag(fiber.flags, FiberFlags.Placement) && fiber.stateNode) {
     const parentDOM = getHostParent(fiber);
     if (parentDOM) {
       parentDOM.appendChild(fiber.stateNode);
@@ -15,7 +17,7 @@ export function commitWork(fiber: FiberNode): void {
   }
 
   // 2. Update 대상일 경우 props 갱신
-  if (fiber.flags === "Update" && fiber.stateNode) {
+  if (hasFiberFlag(fiber.flags, FiberFlags.Update) && fiber.stateNode) {
     patchProps(
       fiber.stateNode,
       fiber.alternate?.memoizedProps,
@@ -25,12 +27,12 @@ export function commitWork(fiber: FiberNode): void {
 
   if (fiber.effects?.length) {
     // LayoutEffect 동기 실행
-    if (typeof fiber.flags === "number" && fiber.flags & 0b0100) {
+    if (hasFiberFlag(fiber.flags, FiberFlags.LayoutEffect)) {
       flushLayoutEffect(fiber.effects);
     }
 
     // PassiveEffect 비동기 실행
-    if (typeof fiber.flags === "number" && fiber.flags & 0b0010) {
+    if (hasFiberFlag(fiber.flags, FiberFlags.PassiveEffect)) {
       queueMicrotask(() => {
         flushPassiveEffect(fiber.effects!);
       });

--- a/src/fiber/core/completeUnitOfWork.ts
+++ b/src/fiber/core/completeUnitOfWork.ts
@@ -1,0 +1,20 @@
+import { FiberNode } from "../type.fiber";
+import { completeWork } from "./completeWork";
+
+export function completeUnitOfWork(fiber: FiberNode): FiberNode | null {
+  let node: FiberNode | null = fiber;
+
+  do {
+    // 1. 현재 노드에 대해 completeWork 수행
+    completeWork(node);
+
+    // 2. 형제 노드가 있으면 형제 노드 반환
+    const siblingNode = node.sibling;
+    if (siblingNode !== null) return siblingNode;
+
+    // 3. 형제 노드가 없으면 부모 노드로 이동
+    node = node.return;
+  } while (node !== null);
+
+  return null;
+}

--- a/src/fiber/core/completeWokr.ts
+++ b/src/fiber/core/completeWokr.ts
@@ -1,8 +1,10 @@
 import { FiberNode } from "../type.fiber";
+import { hasFiberFlag } from "../utils.fiber";
+import { FiberFlags } from "../constants";
 
 export function completeWork(fiber: FiberNode): void {
-  const isPlacement = fiber.flags === "Placement";
-  const isUpdate = fiber.flags === "Update";
+  const isPlacement = hasFiberFlag(fiber.flags, FiberFlags.Placement);
+  const isUpdate = hasFiberFlag(fiber.flags, FiberFlags.Update);
 
   // Host 컴포넌트일 때
   if (typeof fiber.type === "string") {

--- a/src/fiber/core/completeWork.ts
+++ b/src/fiber/core/completeWork.ts
@@ -23,7 +23,4 @@ export function completeWork(fiber: FiberNode): void {
     // props 설정
     fiber.memoizedProps = fiber.pendingProps;
   }
-
-  if (fiber.child) completeWork(fiber.child);
-  if (fiber.sibling) completeWork(fiber.sibling);
 }

--- a/src/fiber/core/createFiberNode.ts
+++ b/src/fiber/core/createFiberNode.ts
@@ -1,5 +1,6 @@
 import { VirtualNode } from "@/jsx/type.jsx";
 import { FiberNode } from "../type.fiber";
+import { FiberFlags } from "../constants";
 
 export function createFiberNode(virtualNode: VirtualNode): FiberNode {
   return {
@@ -12,7 +13,7 @@ export function createFiberNode(virtualNode: VirtualNode): FiberNode {
     return: null,
     alternate: null,
 
-    flags: "Placement",
+    flags: FiberFlags.Placement,
 
     pendingProps: virtualNode.props,
     memoizedProps: null,

--- a/src/fiber/core/createTextFiber.ts
+++ b/src/fiber/core/createTextFiber.ts
@@ -1,4 +1,5 @@
 import { FiberNode } from "../type.fiber";
+import { FiberFlags } from "../constants";
 
 const TEXT_ELEMENT = "TEXT_ELEMENT";
 
@@ -13,7 +14,7 @@ export function createTextFiber(text: string, parent: FiberNode): FiberNode {
     return: parent,
     alternate: null,
 
-    flags: "Placement",
+    flags: FiberFlags.Placement,
 
     pendingProps: { nodeValue: text },
     memoizedProps: null,

--- a/src/fiber/core/performUnitOfWork.ts
+++ b/src/fiber/core/performUnitOfWork.ts
@@ -1,5 +1,6 @@
 import { FiberNode } from "../type.fiber";
 import { beginWork } from "./beginWork";
+import { completeUnitOfWork } from "./completeUnitOfWork";
 
 export function performUnitOfWork(fiber: FiberNode): FiberNode | null {
   // 1. beginWork 수행
@@ -10,23 +11,6 @@ export function performUnitOfWork(fiber: FiberNode): FiberNode | null {
     return next;
   }
 
-  // 3. 자식 노드가 없을 경우 형제 노드 탐색
-  return findNextUnitOfWork(fiber);
-}
-
-function findNextUnitOfWork(fiber: FiberNode | null): FiberNode | null {
-  let node = fiber;
-
-  while (node !== null) {
-    // 1. 형제가 있으면 헝제 노드 반환
-    if (node.sibling !== null) {
-      return node.sibling;
-    }
-
-    // 2. 형제가 없으면 부모로 올라가서 부모의 형제 탐색
-    node = node.return;
-  }
-
-  // 3. 루트까지 올라갈 경우 종료
-  return null;
+  // 3. 자식 노드가 없을 경우 completeUnitOfWork 호출
+  return completeUnitOfWork(fiber);
 }

--- a/src/fiber/core/performUnitOfWork.ts
+++ b/src/fiber/core/performUnitOfWork.ts
@@ -1,0 +1,32 @@
+import { FiberNode } from "../type.fiber";
+import { beginWork } from "./beginWork";
+
+export function performUnitOfWork(fiber: FiberNode): FiberNode | null {
+  // 1. beginWork 수행
+  const next = beginWork(fiber);
+
+  // 2. 자식 노드가 있으면 자식 참조
+  if (next !== null) {
+    return next;
+  }
+
+  // 3. 자식 노드가 없을 경우 형제 노드 탐색
+  return findNextUnitOfWork(fiber);
+}
+
+function findNextUnitOfWork(fiber: FiberNode | null): FiberNode | null {
+  let node = fiber;
+
+  while (node !== null) {
+    // 1. 형제가 있으면 헝제 노드 반환
+    if (node.sibling !== null) {
+      return node.sibling;
+    }
+
+    // 2. 형제가 없으면 부모로 올라가서 부모의 형제 탐색
+    node = node.return;
+  }
+
+  // 3. 루트까지 올라갈 경우 종료
+  return null;
+}

--- a/src/fiber/core/workLoop.ts
+++ b/src/fiber/core/workLoop.ts
@@ -1,0 +1,10 @@
+import { FiberNode } from "../type.fiber";
+import { performUnitOfWork } from "./performUnitOfWork";
+
+export function workLoop(fiber: FiberNode | null): void {
+  let workInProgress: FiberNode | null = fiber;
+
+  while (workInProgress !== null) {
+    workInProgress = performUnitOfWork(workInProgress);
+  }
+}

--- a/src/fiber/hooks/useEffect.ts
+++ b/src/fiber/hooks/useEffect.ts
@@ -52,9 +52,6 @@ function updateEffect(
     fiber?.effects?.push(effect);
 
     if (fiber) {
-      /** flags 타입이 number로 통일되지 않은 상태라 임시 처리 (추후 수정 예정) */
-      if (typeof fiber.flags !== "number") fiber.flags = 0;
-
       if (tag === "Passive") {
         fiber.flags |= 0b0010; // PassiveEffect
       } else {

--- a/src/fiber/legacy/useState_v1/scheduler.ts
+++ b/src/fiber/legacy/useState_v1/scheduler.ts
@@ -1,5 +1,5 @@
 import { beginWork } from "@/fiber/core/beginWork";
-import { completeWork } from "@/fiber/core/completeWokr";
+import { completeWork } from "@/fiber/core/completeWork";
 import { commitWork } from "@/fiber/core//commitWork";
 import type { FiberNode } from "@/fiber/type.fiber";
 

--- a/src/fiber/scheduler/scheduleUpdateOnFiber.ts
+++ b/src/fiber/scheduler/scheduleUpdateOnFiber.ts
@@ -1,6 +1,8 @@
 import { FiberNode } from "../type.fiber";
 import { workLoop } from "../core/workLoop";
+import { commitUnitOfWork } from "../core/commitUnitOfWork";
 
 export function scheduleUpdateOnFiber(fiber: FiberNode) {
   workLoop(fiber);
+  commitUnitOfWork(fiber);
 }

--- a/src/fiber/scheduler/scheduleUpdateOnFiber.ts
+++ b/src/fiber/scheduler/scheduleUpdateOnFiber.ts
@@ -1,6 +1,6 @@
 import { FiberNode } from "../type.fiber";
-import { beginWork } from "../core/beginWork";
+import { workLoop } from "../core/workLoop";
 
 export function scheduleUpdateOnFiber(fiber: FiberNode) {
-  beginWork(fiber);
+  workLoop(fiber);
 }

--- a/src/fiber/type.fiber.ts
+++ b/src/fiber/type.fiber.ts
@@ -10,7 +10,7 @@ export interface FiberNode {
   return: FiberNode | null;
   alternate: FiberNode | null;
 
-  flags: "Placement" | "Update" | "Deletion" | number | null;
+  flags: number;
 
   memoizedProps: any;
   pendingProps: any;

--- a/src/fiber/utils.fiber.ts
+++ b/src/fiber/utils.fiber.ts
@@ -1,6 +1,6 @@
 import { FiberNode } from "./type.fiber";
 
-/** return 포인터를 체이닝을 추적하면서 Host 컴포넌트를 탐색하여 반환하는 함수 */
+/** return 포인터 체이닝을 추적하면서 Host 컴포넌트를 탐색하여 반환하는 함수 */
 export function getHostParent(fiber: FiberNode): HTMLElement | null {
   let parent = fiber.return;
 
@@ -38,4 +38,17 @@ export function patchProps(
       dom.setAttribute(key, nextProps[key]);
     }
   }
+}
+
+/** fiber에 flags를 세팅하는 함수 */
+export function setFiberFlag(currentFlags: number, targetFlag: number): number {
+  return currentFlags | targetFlag;
+}
+
+/** fiber flags 유형을 판별하는 함수 */
+export function hasFiberFlag(
+  currentFlags: number,
+  targetFlag: number
+): boolean {
+  return (currentFlags & targetFlag) !== 0;
 }


### PR DESCRIPTION
## Result
- fiber 트리 순회 방식을 기존 재귀 호출에서 반복문 (`while-loop`) 방식으로 변경

## Work List
- `render phase`에 일시 중단이 가능하도록 `while-loop` 기반의 반복문 기반 순회로 변경 (추후 동시성 모드 등을 활용할 수 있도록 확장성 고려)
- `while-loop` 기반으로 순회할 때 작업 단위를 `performUnitOfWork, completeUnitOfWork` 함수로 세분화 (`beginWork`는 `top-down` 방식으로, `completeWork`는 `bottom-up` 방식으로 처리되도록 구현)
- `commit phase`에서도 `commitUnitOfWork` 함수를 활용하여 `while-loop` 기반으로 `commit`이 처리되도록 변경

## Discussion